### PR TITLE
fix: improve PR review trigger condition

### DIFF
--- a/functions/webhook/triggerReviews.js
+++ b/functions/webhook/triggerReviews.js
@@ -85,7 +85,13 @@ export function shouldTriggerLLMReview(payload) {
 }
 
 export function shouldTriggerRuleBasedReview(payload) {
-  return payload.pull_request && payload.action === 'ready_for_review'
+  const pullRequest = payload.pull_request
+  return (
+    pullRequest &&
+    pullRequest.user.type === 'User' &&
+    (payload.action === 'ready_for_review' ||
+      (payload.action === 'opened' && pullRequest.draft === false))
+  )
 }
 
 export async function triggerLLMReview(context) {


### PR DESCRIPTION
Fixes #121 

Auto-review PRs even if they are not put in draft state when they are created. In addition, do not review bot-created PRs.