### PR TITLE
upgrade node version - nodejs18 to nodejs 20

### DIFF
--- a/.github/workflows/deploy-step.yml
+++ b/.github/workflows/deploy-step.yml
@@ -71,7 +71,7 @@ jobs:
         id: deploy-webhook
         run: >-
           gcloud functions deploy ${{ inputs.WEBHOOK_PATH }}
-          --runtime=nodejs18
+          --runtime=nodejs20
           --source=.
           --entry-point=webhook
           --set-secrets=PRIVATE_KEY=projects/${{ inputs.GCP_PROJECT_ID }}/secrets/gh-private-key-${{ inputs.environment }}:latest
@@ -88,7 +88,7 @@ jobs:
         id: deploy-createReview
         run: >-
           gcloud functions deploy ${{ inputs.CREATE_REVIEW_PATH }}
-          --runtime=nodejs18
+          --runtime=nodejs20
           --source=.
           --entry-point=createReview
           --set-secrets=PRIVATE_KEY=projects/${{ inputs.GCP_PROJECT_ID }}/secrets/gh-private-key-${{ inputs.environment }}:latest


### PR DESCRIPTION
Migrate functions to a newer runtime before the decommission dates.

This PR migrates Google Cloud functions to a newer runtime from Node.js 18 to Node.js 20, before the
decommission dates.

See https://github.com/nearform/hub-draft-issues/issues/376 
